### PR TITLE
pagination active page

### DIFF
--- a/src/pages/user/SearchBookPage/Search.jsx
+++ b/src/pages/user/SearchBookPage/Search.jsx
@@ -9,6 +9,7 @@ const Search = () => {
   const [query, setQuery] = useState({ author: '', title: '' })
   const [isLoading, setIsLoading] = useState(false)
   const [totalPages, setTotalPages] = useState(0)
+  const [currentPage, setCurrentPage] = useState(0)
 
   const searchBook = async (author = '', title = '', index = 0) => {
     console.log('index search', index)
@@ -31,20 +32,23 @@ const Search = () => {
     }
   }
 
+  const handleCurrentPage = (page) => setCurrentPage(page)
+
   useEffect(() => {
-    console.log('total pages', totalPages)
-    console.log('results', results)
-    console.log('query', query)
-  }, [totalPages, query, results])
+    // console.log('total pages', totalPages)
+    // console.log('results', results)
+    // console.log('query', query)
+    console.log('current page from search', currentPage)
+  }, [currentPage])
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-semibold mb-2">Search book</h1>
       <p className="mb-3">Find a book by title, author or both.</p>
-      <SearchBook searchBook={searchBook} />
+      <SearchBook searchBook={searchBook} setCurrentPage={handleCurrentPage} />
       {isLoading ? <Loading /> : null}
       <SearchBookResults results={results} searchBook={searchBook} query={query} totalPages={totalPages} />
-      <ResultsPagination searchBook={searchBook} query={query} totalPages={totalPages} />
+      <ResultsPagination searchBook={searchBook} query={query} totalPages={totalPages} currentPage={currentPage} setCurrentPage={handleCurrentPage} />
     </div>
   )
 }

--- a/src/pages/user/SearchBookPage/components/BookListElement.jsx
+++ b/src/pages/user/SearchBookPage/components/BookListElement.jsx
@@ -31,7 +31,7 @@ const BookListElement = ({ result }) => {
                         <div className='flex flex-col grow'>
 
                             <p className="font-semibold text-lg border-link-active">{result.volumeInfo.title}</p>
-                            <p>{result.volumeInfo.authors}</p>
+                            <p>{result.volumeInfo.authors.slice(0, 15).join(', ')}</p>
                             {/* .slice(0, 3).join(', ') */}
                             {filteredList.length > 0 &&
                                 <p className='text-sm'>

--- a/src/pages/user/SearchBookPage/components/ResultsPagination.jsx
+++ b/src/pages/user/SearchBookPage/components/ResultsPagination.jsx
@@ -1,20 +1,28 @@
 import PropTypes from 'prop-types';
 import ReactPaginate from 'react-paginate';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { useEffect } from 'react';
 
-const ResultsPagination = ({ searchBook, query, totalPages }) => {
+const ResultsPagination = ({ searchBook, query, totalPages, currentPage, setCurrentPage }) => {
 
     const handlePageChange = (selectedPage) => {
         console.log('selected page', selectedPage)
+        setCurrentPage(selectedPage.selected)
         const index = (selectedPage.selected + 1) * 20 - 20;
         console.log('index click', index)
         searchBook(query.author, query.title, index)
     };
 
+    useEffect(() => {
+        console.log('curr page', currentPage)
+        console.log('total pages', totalPages)
+    }, [currentPage, totalPages])
+
     return (
         <div>
             <ReactPaginate
                 pageCount={totalPages}
+                forcePage={currentPage}
                 onPageChange={handlePageChange}
                 breakLabel={"..."}
                 // center numbers - how many : ...4 5 6 ...
@@ -38,4 +46,6 @@ ResultsPagination.propTypes = {
     query: PropTypes.object,
     searchBook: PropTypes.func,
     totalPages: PropTypes.number,
+    currentPage: PropTypes.number,
+    setCurrentPage: PropTypes.func
 }

--- a/src/pages/user/SearchBookPage/components/SearchBookForm.jsx
+++ b/src/pages/user/SearchBookPage/components/SearchBookForm.jsx
@@ -5,7 +5,7 @@ import HintsContainer from "./HintsContainer";
 import { useRef, useEffect, useState } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 
-const SearchBook = ({ searchBook }) => {
+const SearchBook = ({ searchBook, setCurrentPage }) => {
     const titleInputRef = useRef(null)
     const authorInputRef = useRef(null)
     const [showHintsTitle, setShowHintsTitle] = useState(false)
@@ -32,6 +32,7 @@ const SearchBook = ({ searchBook }) => {
         const dataTitle = (values.title).replace(/ /g, '+')
         searchBook(dataAuthor, dataTitle)
         resetForm()
+        setCurrentPage(0)
     }
 
     const validationSchema = Yup.object({
@@ -116,4 +117,5 @@ export default SearchBook
 
 SearchBook.propTypes = {
     searchBook: PropTypes.func,
+    setCurrentPage: PropTypes.func,
 }


### PR DESCRIPTION
- before: after new search with API, active page does not reset in the pagination - it is still the last page clicked from penultimate API search, not '1'
- now: active page in pagination - corrected with forcePage prop, but still error in the console: The forcePage prop provided is greater than the maximum page index from pageCount prop 
- github issue: https://github.com/AdeleD/react-paginate/issues/198 